### PR TITLE
GH Action: Update apt before pulling upgrades

### DIFF
--- a/.github/workflows/compile-build-test.yml
+++ b/.github/workflows/compile-build-test.yml
@@ -10,6 +10,7 @@ jobs:
             - uses: actions/checkout@v2
             - name: Install pre-reqs
               run: |
+                  sudo apt-get update
                   sudo apt-get -y install libgmp-dev libxml2-dev libjansson-dev libtokyocabinet-dev libpopt-dev qtbase5-dev libqt5svg5-dev python3-all-dev doxygen libgraphviz-dev pkg-config xsltproc libcppunit-dev
             - name: Configure
               run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Without this, the action fails sometimes when versions update